### PR TITLE
Convert to CMake and make it work on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8.0)
+
+project( MagicProject )
+
+add_executable( magic 
+    main.cpp 
+)
+
+set_property( TARGET magic PROPERTY CXX_STANDARD 17 )

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-magic:
-	g++ -std=c++17 -g main.cpp -o magic
-
-all: magic
-
-clean:
-	rm magic
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+Build instructions
+------------------
+
+Either in the root folder or in `identity-theft` folder, run the following commands:
+
+**Linux**:
+```bash
+mkdir build 
+cd build
+cmake -G "Unix Makefiles" ..
+cmake --build .
+```
+
+Run with either:
+```bash
+./magic
+```
+Or:
+```
+./identityTheft
+```
+
+**Windows**
+```bash
+md build 
+cd build
+cmake -G "Visual Studio 15 2017" ..
+cmake --build .
+```
+Run with either:
+```bash
+Debug\magic
+```
+Or:
+```
+Debug\identityTheft
+```

--- a/identity-theft/CMakeLists.txt
+++ b/identity-theft/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.8.0)
+
+project( IdentityTheftProject )
+
+add_definitions(
+    -D IDENTITY_THEFT_DLL
+)
+
+add_executable( identityTheft
+    thief.cpp 
+)
+
+add_library( holder SHARED
+    holder.cpp
+)
+
+target_link_libraries( identityTheft
+    holder
+)
+
+set_property( TARGET identityTheft PROPERTY CXX_STANDARD 17 )

--- a/identity-theft/CMakeLists.txt
+++ b/identity-theft/CMakeLists.txt
@@ -19,3 +19,4 @@ target_link_libraries( identityTheft
 )
 
 set_property( TARGET identityTheft PROPERTY CXX_STANDARD 17 )
+set_property( TARGET holder        PROPERTY CXX_STANDARD 17 )

--- a/identity-theft/CMakeLists.txt
+++ b/identity-theft/CMakeLists.txt
@@ -2,9 +2,11 @@ cmake_minimum_required(VERSION 3.8.0)
 
 project( IdentityTheftProject )
 
-add_definitions(
-    -D IDENTITY_THEFT_DLL
-)
+if( WIN32 )
+    add_definitions(
+        -D IDENTITY_THEFT_DLL
+    )
+endif()
 
 add_executable( identityTheft
     thief.cpp 

--- a/identity-theft/dummy.h
+++ b/identity-theft/dummy.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef IDENTITY_THEFT_DLL
+#   ifdef _WINDLL
+#       define IDENTITY_THEFT_API __declspec(dllexport)
+#   else
+#       define IDENTITY_THEFT_API __declspec(dllimport)
+#   endif
+#else
+#   define IDENTITY_THEFT_API
+#endif
+
+extern void IDENTITY_THEFT_API dummy();

--- a/identity-theft/holder.cpp
+++ b/identity-theft/holder.cpp
@@ -1,6 +1,8 @@
-#include<iostream>
+#include <iostream>
+#include "dummy.h"
 
-void dummy(){} // here just so the library will be loaded
+void dummy()  // here just so the library will be loaded
+{}
 
 struct secret_holder
 {

--- a/identity-theft/perform_trick.sh
+++ b/identity-theft/perform_trick.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -x
-
-g++ -c -fpic holder.cpp
-g++ -shared -o libholder.so holder.o
-g++ -L. thief.cpp -lholder -o test
-LD_LIBRARY_PATH="$(pwd)" ./test

--- a/identity-theft/thief.cpp
+++ b/identity-theft/thief.cpp
@@ -1,7 +1,6 @@
-extern void dummy();
-int main() { dummy(); }
+#include <iostream>
+#include "dummy.h"
 
-#include<iostream>
 struct thief
 {
     thief()
@@ -26,3 +25,8 @@ struct thief
 };
 
 thief joe_bloggs;
+
+int main() 
+{ 
+    dummy(); 
+}


### PR DESCRIPTION
Removed makefile and shell script for building. Added CMake.

Made it work on Windows. (Note: Identity Theft does not work on Windows as advertised due to ODR differences.)